### PR TITLE
sf2 compliance: replace deprecated SecurityContextInterface

### DIFF
--- a/Resources/config/services/security.xml
+++ b/Resources/config/services/security.xml
@@ -16,7 +16,7 @@
         <service id="rezzza.security.request_signature.provider" class="%rezzza.security.request_signature.provider.class%" public="false" />
 
         <service id="rezzza.security.request_signature.listener" class="%rezzza.security.request_signature.listener.class%" public="false">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- injected via RequestSignatureFactory -->
             <argument /> <!-- injected via RequestSignatureFactory -->

--- a/Security/Firewall/RequestSignatureListener.php
+++ b/Security/Firewall/RequestSignatureListener.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Rezzza\SecurityBundle\Security\RequestSignatureToken;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * RequestSignatureListener

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle" : "~2.0",
+        "symfony/framework-bundle": "~2.6",
+        "symfony/security-bundle" : "~2.6",
         "doctrine/common": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/rezzza/SecurityBundle/blob/master/Security/Firewall/RequestSignatureListener.php#L31

https://github.com/symfony/symfony/blob/2.7/UPGRADE-2.6.md#security